### PR TITLE
Added required parameter to __unserialize()

### DIFF
--- a/src/Enumeration/Enumeration.php
+++ b/src/Enumeration/Enumeration.php
@@ -212,7 +212,7 @@ abstract class Enumeration implements StaticConstructorInterface, Serializable
         throw new EnumerationException('Enum serialization is not allowed');
     }
 
-    final public function __unserialize()
+    final public function __unserialize($data)
     {
         throw new EnumerationException('Enum unserialization is not allowed');
     }


### PR DESCRIPTION
 Added required parameter to __unserialize() method to avoid compile errors in PHP 8 with "declare(strict_types=1)".